### PR TITLE
Add runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ err := svc.ResolveConfigFromInto(configString, groups, &result)
 ```
 Alternatively you can store the configuration using `SetConfigToResolve` and then call `ResolveConfig` or `ResolveConfigInto`.
 
+## Example
+Run the example to see the resolver in action:
+
+```bash
+go run ./example
+```
+
+`example/main.go` reads `example/config.json`, resolves it for a user in the `paid-user` and `discount` groups and prints the resulting JSON configuration.
+
 ## License
 This library is released under the MIT License.
 

--- a/example/config.json
+++ b/example/config.json
@@ -1,0 +1,36 @@
+{
+  "override-rules": [
+    {
+      "user-is-in-all-groups": ["paid-user", "premium-user"],
+      "override": {"show-adds": false}
+    },
+    {
+      "user-is-in-any-group": ["new-joiner"],
+      "override": {
+        "show-new-joiner-banner": true,
+        "show-full-layout": false
+      }
+    },
+    {
+      "user-is-none-of-the-groups": ["button-blue"],
+      "override": {"button-color": "gray"}
+    },
+    {
+      "custom-expression": "#user.contains('discount') or #user.contains('black-friday')",
+      "override": {
+        "shop.no-of-products": 20,
+        "shop.price-multiplier": 0
+      }
+    }
+  ],
+  "default-properties": {
+    "show-new-joiner-banner": false,
+    "show-adds": true,
+    "show-full-layout": true,
+    "button-color": "blue",
+    "shop": {
+      "no-of-products": 10,
+      "price-multiplier": 2
+    }
+  }
+}

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/example/user-config-resolver-go/pkg/jsonresolver"
+)
+
+type ShopConfig struct {
+	NoOfProducts    int `json:"no-of-products"`
+	PriceMultiplier int `json:"price-multiplier"`
+}
+
+type ExampleConfig struct {
+	ShowNewJoinerBanner bool       `json:"show-new-joiner-banner"`
+	ShowAdds            bool       `json:"show-adds"`
+	ShowFullLayout      bool       `json:"show-full-layout"`
+	ButtonColor         string     `json:"button-color"`
+	Shop                ShopConfig `json:"shop"`
+}
+
+func main() {
+	// Read the configuration file.
+	raw, err := os.ReadFile("example/config.json")
+	if err != nil {
+		panic(err)
+	}
+
+	// Groups that the current user belongs to.
+	groups := []string{"paid-user", "discount"}
+
+	svc := jsonresolver.New()
+	var result ExampleConfig
+	if err := svc.ResolveConfigFromInto(string(raw), groups, &result); err != nil {
+		panic(err)
+	}
+
+	// Print the resolved configuration.
+	out, _ := json.MarshalIndent(result, "", "  ")
+	fmt.Println(string(out))
+}


### PR DESCRIPTION
## Summary
- add runnable example under `example/`
- document running example in README

## Testing
- `go test ./...`
- `go run ./example | head`

------
https://chatgpt.com/codex/tasks/task_e_684e79dd1cec832ebcd075367f287f28