### PR TITLE
Refactor ApplyRules to avoid mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ You may want to adapt application behaviour for different user groups. Instead o
 ## Features
 - **User Group-Based Overrides:** override configuration properties when a user is in specific groups.
 - **Custom Expression Support:** use simple expressions to create complex conditions.
-- **Resolve to Structs or JSON:** resolve configuration into Go structs or as JSON strings.
+ - **Resolve to Structs or JSON:** resolve configuration into Go structs or as JSON strings.
+ - **Reuse Parsed Configs:** pass a previously unmarshalled `resolver.Config` to avoid repeated JSON parsing.
 
 ## Installation
 ```bash
@@ -68,9 +69,14 @@ import resjson "github.com/example/user-config-resolver-go/resolver/json"
 
 svc := resjson.New()
 var result MyConfigStruct
-err := svc.ResolveConfigFromInto(configString, groups, &result)
+err := svc.ResolveStringToStruct(configString, groups, &result)
 ```
-Alternatively you can store the configuration using `SetConfigToResolve` and then call `ResolveConfig` or `ResolveConfigInto`.
+Alternatively you can unmarshal the JSON once into `resolver.Config` and resolve from the struct:
+```go
+var cfg resolver.Config
+_ = json.Unmarshal([]byte(configString), &cfg)
+err := svc.ResolveStructToStruct(&cfg, groups, &result)
+```
 
 ## Example
 Run the example to see the resolver in action:

--- a/example/main.go
+++ b/example/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	svc := resjson.New()
 	var result ExampleConfig
-	if err := svc.ResolveConfigFromInto(string(raw), groups, &result); err != nil {
+	if err := svc.ResolveStringToStruct(string(raw), groups, &result); err != nil {
 		panic(err)
 	}
 

--- a/resolver/logic_test.go
+++ b/resolver/logic_test.go
@@ -15,10 +15,14 @@ func TestApplyRules(t *testing.T) {
 		},
 	}
 	groups := []string{"a", "b"}
-	ApplyRules(groups, &c)
-	foo := c.DefaultProperties["foo"].(map[string]interface{})
+	resolved := ApplyRules(groups, &c)
+	foo := resolved.DefaultProperties["foo"].(map[string]interface{})
 	if foo["bar"] != 2 {
 		t.Fatalf("expected override to apply")
+	}
+	origFoo := c.DefaultProperties["foo"].(map[string]interface{})
+	if origFoo["bar"] != 1 {
+		t.Fatalf("original config was mutated")
 	}
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -2,11 +2,10 @@ package resolver
 
 // ConfigResolver defines the interface for resolving user-specific configuration.
 type ConfigResolver interface {
-	SetConfigToResolve(config string)
-	ResolveConfig(userGroups []string) (string, error)
-	ResolveConfigInto(userGroups []string, target any) error
-	ResolveConfigFrom(config string, userGroups []string) (string, error)
-	ResolveConfigFromInto(config string, userGroups []string, target any) error
+	ResolveStringToString(input string, groups []string) (string, error)
+	ResolveStringToStruct(input string, groups []string, out any) error
+	ResolveStructToString(cfg *Config, groups []string) (string, error)
+	ResolveStructToStruct(cfg *Config, groups []string, out any) error
 }
 
 type ConfigResolverError struct{ Err error }


### PR DESCRIPTION
## Summary
- return a new `Config` from `ApplyRules` to keep input unchanged
- remove deep copy helper file and copy inside logic
- update JSON resolver to use new `ApplyRules`
- adjust tests for non-mutating behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f060b9ff0832e911c2d22ce051ff8