### PR TITLE
Remove stored configuration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ svc := resjson.New()
 var result MyConfigStruct
 err := svc.ResolveConfigFromInto(configString, groups, &result)
 ```
-Alternatively you can store the configuration using `SetConfigToResolve` and then call `ResolveConfig` or `ResolveConfigInto`.
+
 
 ## Example
 Run the example to see the resolver in action:

--- a/resolver/json/resolver.go
+++ b/resolver/json/resolver.go
@@ -2,33 +2,14 @@ package json
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/example/user-config-resolver-go/resolver"
 )
 
-type JsonConfigResolverService struct {
-	configToResolve string
-}
+type JsonConfigResolverService struct{}
 
 func New() *JsonConfigResolverService { return &JsonConfigResolverService{} }
-
-func (s *JsonConfigResolverService) SetConfigToResolve(config string) { s.configToResolve = config }
-
-func (s *JsonConfigResolverService) ResolveConfig(groups []string) (string, error) {
-	if s.configToResolve == "" {
-		return "", resolver.ConfigResolverError{Err: fmt.Errorf("config to resolve is empty")}
-	}
-	return s.ResolveConfigFrom(s.configToResolve, groups)
-}
-
-func (s *JsonConfigResolverService) ResolveConfigInto(groups []string, target any) error {
-	if s.configToResolve == "" {
-		return resolver.ConfigResolverError{Err: fmt.Errorf("config to resolve is empty")}
-	}
-	return s.ResolveConfigFromInto(s.configToResolve, groups, target)
-}
 
 func (s *JsonConfigResolverService) ResolveConfigFrom(cfg string, groups []string) (string, error) {
 	var out string

--- a/resolver/json/resolver_test.go
+++ b/resolver/json/resolver_test.go
@@ -62,40 +62,6 @@ func TestResolveFromString(t *testing.T) {
 	}
 }
 
-func TestResolveStoredInto(t *testing.T) {
-	svc := New()
-	for _, tc := range testCases() {
-		in, _ := readFile(tc.in)
-		var expected TestDto
-		_ = readFileInto(tc.out, &expected)
-		svc.SetConfigToResolve(in)
-		var result TestDto
-		if err := svc.ResolveConfigInto(tc.groups, &result); err != nil {
-			t.Fatal(err)
-		}
-		if result != expected {
-			t.Errorf("unexpected result for %s", tc.in)
-		}
-	}
-}
-
-func TestResolveStoredString(t *testing.T) {
-	svc := New()
-	for _, tc := range testCases() {
-		in, _ := readFile(tc.in)
-		expected, _ := readFile(tc.out)
-		expected = compact(expected)
-		svc.SetConfigToResolve(in)
-		out, err := svc.ResolveConfig(tc.groups)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if out != expected {
-			t.Errorf("unexpected result for %s", tc.in)
-		}
-	}
-}
-
 func TestInvalidInput(t *testing.T) {
 	svc := New()
 	groups := []string{"group-a", "group-b"}
@@ -105,13 +71,6 @@ func TestInvalidInput(t *testing.T) {
 		t.Error("expected error")
 	}
 	if _, err := svc.ResolveConfigFrom(in, groups); err == nil {
-		t.Error("expected error")
-	}
-	svc.SetConfigToResolve(in)
-	if _, err := svc.ResolveConfig(groups); err == nil {
-		t.Error("expected error")
-	}
-	if err := svc.ResolveConfigInto(groups, &v); err == nil {
 		t.Error("expected error")
 	}
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -2,9 +2,6 @@ package resolver
 
 // ConfigResolver defines the interface for resolving user-specific configuration.
 type ConfigResolver interface {
-	SetConfigToResolve(config string)
-	ResolveConfig(userGroups []string) (string, error)
-	ResolveConfigInto(userGroups []string, target any) error
 	ResolveConfigFrom(config string, userGroups []string) (string, error)
 	ResolveConfigFromInto(config string, userGroups []string, target any) error
 }


### PR DESCRIPTION
## Summary
- remove SetConfigToResolve and stored config methods
- update JSON resolver accordingly
- drop tests that used stored config
- update README to show only passing config as parameter

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f1d29dcf8832e94e9222f5b21f419