### PR TITLE
Clarify ConfigResolver API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ import resjson "github.com/example/user-config-resolver-go/resolver/json"
 
 svc := resjson.New()
 var result MyConfigStruct
-err := svc.ResolveConfigFromInto(configString, groups, &result)
+err := svc.ResolveInto(configString, groups, &result)
 ```
 
 

--- a/example/main.go
+++ b/example/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	svc := resjson.New()
 	var result ExampleConfig
-	if err := svc.ResolveConfigFromInto(string(raw), groups, &result); err != nil {
+	if err := svc.ResolveInto(string(raw), groups, &result); err != nil {
 		panic(err)
 	}
 

--- a/resolver/json/resolver.go
+++ b/resolver/json/resolver.go
@@ -11,15 +11,17 @@ type JsonConfigResolverService struct{}
 
 func New() *JsonConfigResolverService { return &JsonConfigResolverService{} }
 
-func (s *JsonConfigResolverService) ResolveConfigFrom(cfg string, groups []string) (string, error) {
+// Resolve returns the resolved configuration as a JSON string.
+func (s *JsonConfigResolverService) Resolve(cfg string, groups []string) (string, error) {
 	var out string
-	if err := s.ResolveConfigFromInto(cfg, groups, &out); err != nil {
+	if err := s.ResolveInto(cfg, groups, &out); err != nil {
 		return "", err
 	}
 	return out, nil
 }
 
-func (s *JsonConfigResolverService) ResolveConfigFromInto(cfg string, groups []string, target any) error {
+// ResolveInto unmarshals the resolved configuration into target.
+func (s *JsonConfigResolverService) ResolveInto(cfg string, groups []string, target any) error {
 	var c resolver.Config
 	dec := json.NewDecoder(strings.NewReader(cfg))
 	dec.DisallowUnknownFields()

--- a/resolver/json/resolver_test.go
+++ b/resolver/json/resolver_test.go
@@ -19,7 +19,7 @@ func testCases() []struct {
 	}
 }
 
-func TestResolveFromInto(t *testing.T) {
+func TestResolveInto(t *testing.T) {
 	svc := New()
 	for _, tc := range testCases() {
 		in, err := readFile(tc.in)
@@ -31,7 +31,7 @@ func TestResolveFromInto(t *testing.T) {
 			t.Fatal(err)
 		}
 		var result TestDto
-		if err := svc.ResolveConfigFromInto(in, tc.groups, &result); err != nil {
+		if err := svc.ResolveInto(in, tc.groups, &result); err != nil {
 			t.Fatal(err)
 		}
 		if result != expected {
@@ -40,7 +40,7 @@ func TestResolveFromInto(t *testing.T) {
 	}
 }
 
-func TestResolveFromString(t *testing.T) {
+func TestResolve(t *testing.T) {
 	svc := New()
 	for _, tc := range testCases() {
 		in, err := readFile(tc.in)
@@ -52,7 +52,7 @@ func TestResolveFromString(t *testing.T) {
 			t.Fatal(err)
 		}
 		expected = compact(expected)
-		out, err := svc.ResolveConfigFrom(in, tc.groups)
+		out, err := svc.Resolve(in, tc.groups)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -67,10 +67,10 @@ func TestInvalidInput(t *testing.T) {
 	groups := []string{"group-a", "group-b"}
 	in, _ := readFile("invalid-config/input.json")
 	var v TestDto
-	if err := svc.ResolveConfigFromInto(in, groups, &v); err == nil {
+	if err := svc.ResolveInto(in, groups, &v); err == nil {
 		t.Error("expected error")
 	}
-	if _, err := svc.ResolveConfigFrom(in, groups); err == nil {
+	if _, err := svc.Resolve(in, groups); err == nil {
 		t.Error("expected error")
 	}
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,9 +1,18 @@
 package resolver
 
-// ConfigResolver defines the interface for resolving user-specific configuration.
+// ConfigResolver resolves configuration for a set of user groups.
+//
+// Implementations parse the provided configuration rules, apply the group based
+// overrides and return the resulting configuration either as a JSON string or by
+// unmarshalling it into the supplied target value.
 type ConfigResolver interface {
-	ResolveConfigFrom(config string, userGroups []string) (string, error)
-	ResolveConfigFromInto(config string, userGroups []string, target any) error
+	// Resolve parses the configuration and returns the resolved JSON.
+	Resolve(config string, userGroups []string) (string, error)
+
+	// ResolveInto parses the configuration and populates target with the
+	// resolved values. Target must be a pointer to the destination struct or
+	// another value that can be unmarshalled by the implementation.
+	ResolveInto(config string, userGroups []string, target any) error
 }
 
 type ConfigResolverError struct{ Err error }


### PR DESCRIPTION
## Summary
- rename methods in `ConfigResolver` to `Resolve` and `ResolveInto`
- update JSON resolver implementation
- update tests, example, and README to use the new API

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684f20970e0c832eb1e7a8aa5b8a537c